### PR TITLE
fix: Connect to bootstrap peers on startup

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -137,6 +137,16 @@ func NewPeer(
 		return nil, err
 	}
 
+	for _, peer := range peers {
+		// We try to connect to bootstrap peers.
+		addrs := make([]string, len(peer.Addrs))
+		for i, addr := range peer.Addrs {
+			addrs[i] = addr.String()
+		}
+		// We can ignore the error as the peer might be offline and that is ok.
+		_ = p.Connect(ctx, peer.ID.String(), addrs)
+	}
+
 	// There is a possibility for the PeerInfo event to trigger before the PeerInfo has been set for the host.
 	// To avoid this, we wait for the host to indicate that its local address has been updated.
 	sub, err := h.EventBus().Subscribe(&libp2pevent.EvtLocalAddressesUpdated{})


### PR DESCRIPTION
## Description

This PR fixes a devex issue where bootstrap instance would not be connected to until a message was sent over the pubsub network. This resulted it the bootstrap instance not knowing about the new instance until later than expected.

The workaround for this was to call Connect instead of (or in addition to) defining a bootstrap instance.

With this fix, the bootstrapped instance will know about the new instance as soon as it goes online. 
