### PR TITLE
chore: Make connect multiaddress friendly

### DIFF
--- a/p2p.go
+++ b/p2p.go
@@ -14,7 +14,6 @@ package p2p
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 
 	"github.com/ipfs/go-cid"
@@ -28,16 +27,6 @@ var (
 type StreamHandler = func(stream io.Reader, peerID string)
 type PubsubMessageHandler = func(from string, topic string, msg []byte) ([]byte, error)
 type BlockAccessFunc = func(ctx context.Context, peerID string, c cid.Cid) bool
-
-type PeerInfo struct {
-	ID        string
-	Addresses []string
-}
-
-func (p PeerInfo) String() string {
-	b, _ := json.Marshal(p)
-	return string(b)
-}
 
 type PubsubResponse struct {
 	// ID is the cid.Cid of the received message.

--- a/peer.go
+++ b/peer.go
@@ -139,16 +139,11 @@ func NewPeer(
 
 	for _, peer := range peers {
 		// We try to connect to bootstrap peers.
-		addrs := make([]string, len(peer.Addrs))
-		for i, addr := range peer.Addrs {
-			addrs[i] = addr.String()
-		}
 		// We can ignore the error as the peer might be offline and that is ok.
-		_ = p.Connect(ctx, peer.ID.String(), addrs)
+		_ = p.connect(ctx, peer)
 	}
 
-	// There is a possibility for the PeerInfo event to trigger before the PeerInfo has been set for the host.
-	// To avoid this, we wait for the host to indicate that its local address has been updated.
+	// To ensure we have a full address, we wait for the host to indicate that its local address has been updated.
 	sub, err := h.EventBus().Subscribe(&libp2pevent.EvtLocalAddressesUpdated{})
 	if err != nil {
 		return nil, err

--- a/peer_test.go
+++ b/peer_test.go
@@ -47,7 +47,9 @@ func TestStart_WithKnownPeer_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer n2.Close()
 
-	err = n2.Connect(ctx, n1.PeerInfo().ID, n1.PeerInfo().Addresses)
+	addrs, err := n1.Addresses()
+	require.NoError(t, err)
+	err = n2.Connect(ctx, addrs)
 	require.NoError(t, err)
 }
 
@@ -110,7 +112,11 @@ func TestListenAddrs_WithListenAddresses_NoError(t *testing.T) {
 		WithListenAddresses("/ip4/127.0.0.1/tcp/0"),
 	)
 	require.NoError(t, err)
-	require.Contains(t, n.Addrs()[0], "/tcp/")
+	addrs, err := n.Addresses()
+	require.NoError(t, err)
+	require.NotEmpty(t, addrs)
+	// ensure we have a tcp addr
+	require.Contains(t, addrs[0], "/tcp/")
 	n.Close()
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3

## Description

This PR aims to streamline requesting address information from one peer and using it to connect to another by making multiaddresses that include peer IDs the native information type.