### PR TITLE
chore: Alias pubsub response type

### DIFF
--- a/p2p.go
+++ b/p2p.go
@@ -28,7 +28,7 @@ type StreamHandler = func(stream io.Reader, peerID string)
 type PubsubMessageHandler = func(from string, topic string, msg []byte) ([]byte, error)
 type BlockAccessFunc = func(ctx context.Context, peerID string, c cid.Cid) bool
 
-type PubsubResponse struct {
+type PubsubResponse = struct {
 	// ID is the cid.Cid of the received message.
 	ID string
 	// From is the ID of the sender.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #10 

## Description

This PR changes the return type of `PublishToTopic` from a concrete `go-p2p` type to a type alias that matches the DefraDB `Host` interface return type for `PublishToTopic`.