### PR TITLE
fix: consistent PeerID casing in logs

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -117,7 +117,7 @@ func NewPeer(
 	log.InfoContext(
 		ctx,
 		"Created LibP2P host",
-		corelog.Any("PeerId", h.ID()),
+		corelog.Any("PeerID", h.ID()),
 		corelog.Any("Address", options.ListenAddresses),
 	)
 


### PR DESCRIPTION
fixes sourcenetwork/defradb#4281

