### PR TITLE
feat: Added ResourceLimits and resource controls functionality

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,6 +21,18 @@ import (
 	"github.com/sourcenetwork/immutable"
 )
 
+// ResourceLimits configures the maximum resources available to the P2P host.
+// Connection, stream, and file descriptor limits are derived from these values.
+// A zero value means use a sensible default (half of system resources).
+type ResourceLimits struct {
+	// MaxMemory is the maximum memory in bytes available to the P2P host.
+	// 0 means use half of system RAM.
+	MaxMemory int64
+	// MaxFileDescriptors is the maximum number of file descriptors available to the P2P host.
+	// 0 means skip FD limits and let libp2p autoscale.
+	MaxFileDescriptors int
+}
+
 // Options is the node options.
 type Options struct {
 	ListenAddresses []string
@@ -30,6 +42,7 @@ type Options struct {
 	BootstrapPeers  []string
 
 	ResourceManager network.ResourceManager
+	ResourceLimits  immutable.Option[ResourceLimits]
 
 	Blockstore          immutable.Option[blockstore.Blockstore]
 	BlockstoreChunkSize immutable.Option[int]
@@ -83,10 +96,21 @@ func WithListenAddresses(addresses ...string) NodeOpt {
 
 // WithResourceManager sets resource manager for p2p host
 //
-// If ResourceManager is not provided libp2p will use its default autoscaled resource manager
+// If ResourceManager is not provided, we will attempt to read ResourceLimits
+// and derive a ResourceManager
 func WithResourceManager(rcmgr network.ResourceManager) NodeOpt {
 	return func(opt *Options) {
 		opt.ResourceManager = rcmgr
+	}
+}
+
+// WithResourceLimits sets the memory and file descriptor limits for the P2P host.
+//
+// If WithResourceManager is also set, it takes precedence and this option is ignored.
+// If neither is provided, libp2p will use its default autoscaled resource manager.
+func WithResourceLimits(limits ResourceLimits) NodeOpt {
+	return func(opt *Options) {
+		opt.ResourceLimits = immutable.Some(limits)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ type ResourceLimits struct {
 	// 0 means use half of system RAM.
 	MaxMemory int64
 	// MaxFileDescriptors is the maximum number of file descriptors available to the P2P host.
-	// 0 means skip FD limits and let libp2p autoscale.
+	// 0 means libp2p auto-detects and sets the system file descriptor limit.
 	MaxFileDescriptors int
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -15,7 +15,6 @@ package p2p
 import (
 	"testing"
 
-	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,9 +49,9 @@ func TestWithPrivateKey(t *testing.T) {
 	assert.Equal(t, []byte("abc"), opts.PrivateKey)
 }
 
-func TestWithResourceManager(t *testing.T) {
+func TestWithResourceLimits(t *testing.T) {
 	opts := &Options{}
-	rm := &network.NullResourceManager{}
-	WithResourceManager(rm)(opts)
-	assert.Equal(t, rm, opts.ResourceManager)
+	limits := ResourceLimits{MaxMemory: 512 * 1024 * 1024, MaxFileDescriptors: 256}
+	WithResourceLimits(limits)(opts)
+	assert.Equal(t, limits, opts.ResourceLimits.Value())
 }

--- a/config_test.go
+++ b/config_test.go
@@ -15,6 +15,7 @@ package p2p
 import (
 	"testing"
 
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,6 +48,13 @@ func TestWithPrivateKey(t *testing.T) {
 	opts := &Options{}
 	WithPrivateKey([]byte("abc"))(opts)
 	assert.Equal(t, []byte("abc"), opts.PrivateKey)
+}
+
+func TestWithResourceManager(t *testing.T) {
+	opts := &Options{}
+	rm := &network.NullResourceManager{}
+	WithResourceManager(rm)(opts)
+	assert.Equal(t, rm, opts.ResourceManager)
 }
 
 func TestWithResourceLimits(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -26,8 +26,12 @@ var (
 	ErrTimeoutWaitingForPeerInfo = errors.New("timeout waiting for peer info")
 	ErrContextDone               = errors.New("context done")
 	// ErrHashMismatch is an error returned when the hash of a block is different than expected.
-	ErrHashMismatch             = errors.New("block in storage has different hash than requested")
-	ErrBlockstoreOrRootRequired = errors.New("either blockstore or rootstore must be provided")
+	ErrHashMismatch               = errors.New("block in storage has different hash than requested")
+	ErrBlockstoreOrRootRequired   = errors.New("either blockstore or rootstore must be provided")
+	ErrNegativeMaxMemory          = errors.New("ResourceLimits.MaxMemory must be >= 0")
+	ErrNegativeMaxFileDescriptors = errors.New("ResourceLimits.MaxFileDescriptors must be >= 0")
+	ErrMaxMemoryTooLow            = errors.New("ResourceLimits.MaxMemory must be 0 (autoscale) or >= 128 MiB")
+	ErrMaxFileDescriptorsTooLow   = errors.New("ResourceLimits.MaxFileDescriptors must be 0 (autoscale) or >= 128")
 )
 
 func NewErrPushLog(inner error, topic string) error {

--- a/errors.go
+++ b/errors.go
@@ -30,8 +30,8 @@ var (
 	ErrBlockstoreOrRootRequired   = errors.New("either blockstore or rootstore must be provided")
 	ErrNegativeMaxMemory          = errors.New("ResourceLimits.MaxMemory must be >= 0")
 	ErrNegativeMaxFileDescriptors = errors.New("ResourceLimits.MaxFileDescriptors must be >= 0")
-	ErrMaxMemoryTooLow            = errors.New("ResourceLimits.MaxMemory must be 0 (autoscale) or >= 128 MiB")
-	ErrMaxFileDescriptorsTooLow   = errors.New("ResourceLimits.MaxFileDescriptors must be 0 (autoscale) or >= 128")
+	ErrMaxMemoryTooLow            = errors.New("ResourceLimits.MaxMemory must be 0 (autodetect) or >= 128 MiB")
+	ErrMaxFileDescriptorsTooLow   = errors.New("ResourceLimits.MaxFileDescriptors must be 0 (autodetect) or >= 256")
 )
 
 func NewErrPushLog(inner error, topic string) error {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.15.0
 	github.com/libp2p/go-libp2p-record v0.3.1
 	github.com/multiformats/go-multiaddr v0.16.1
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/sourcenetwork/corekv v0.3.1
 	github.com/sourcenetwork/corekv/blockstore v0.3.1
 	github.com/sourcenetwork/corekv/chunk v0.3.1
@@ -91,7 +92,6 @@ require (
 	github.com/multiformats/go-multistream v0.6.1 // indirect
 	github.com/multiformats/go-varint v0.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pion/datachannel v1.5.10 // indirect
 	github.com/pion/dtls/v3 v3.1.2 // indirect
 	github.com/pion/ice/v4 v4.0.10 // indirect

--- a/host.go
+++ b/host.go
@@ -15,7 +15,6 @@ package p2p
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/ipfs/boxo/blockservice"
 	"github.com/ipld/go-ipld-prime/storage/bsrvadapter"
@@ -30,7 +29,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/routing"
-	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	ma "github.com/multiformats/go-multiaddr"
 
@@ -41,11 +39,6 @@ import (
 
 // setupHost returns a host and router configured with the given options.
 func setupHost(ctx context.Context, options *Options) (host.Host, *dualdht.DHT, error) {
-	connManager, err := connmgr.NewConnManager(100, 400, connmgr.WithGracePeriod(time.Second*20))
-	if err != nil {
-		return nil, nil, err
-	}
-
 	dhtOpts := []dualdht.Option{
 		dualdht.DHTOption(dht.NamespacedValidator("pk", record.PublicKeyValidator{})),
 		dualdht.DHTOption(dht.Concurrency(10)),
@@ -54,12 +47,12 @@ func setupHost(ctx context.Context, options *Options) (host.Host, *dualdht.DHT, 
 
 	var ddht *dualdht.DHT
 	routing := func(h host.Host) (routing.PeerRouting, error) {
+		var err error
 		ddht, err = dualdht.New(ctx, h, dhtOpts...)
 		return ddht, err
 	}
 
 	libp2pOpts := []libp2p.Option{
-		libp2p.ConnectionManager(connManager),
 		libp2p.DefaultTransports,
 		libp2p.ListenAddrStrings(options.ListenAddresses...),
 		libp2p.Routing(routing),
@@ -79,9 +72,13 @@ func setupHost(ctx context.Context, options *Options) (host.Host, *dualdht.DHT, 
 		libp2pOpts = append(libp2pOpts, libp2p.Identity(privateKey))
 	}
 
-	// enable rcmgr option, otherwise fallback to libp2p defaults
-	if options.ResourceManager != nil {
-		libp2pOpts = append(libp2pOpts, libp2p.ResourceManager(options.ResourceManager))
+	connManager, rm, err := buildResourceControls(options)
+	if err != nil {
+		return nil, nil, err
+	}
+	libp2pOpts = append(libp2pOpts, libp2p.ConnectionManager(connManager))
+	if rm != nil {
+		libp2pOpts = append(libp2pOpts, libp2p.ResourceManager(rm))
 	}
 
 	h, err := libp2p.New(libp2pOpts...)

--- a/resource_manager.go
+++ b/resource_manager.go
@@ -1,0 +1,136 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p2p
+
+import (
+	"time"
+
+	libp2p "github.com/libp2p/go-libp2p"
+	iconnmgr "github.com/libp2p/go-libp2p/core/connmgr"
+	"github.com/libp2p/go-libp2p/core/network"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	connmgr "github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	"github.com/pbnjay/memory"
+)
+
+const (
+	connMgrGracePeriod      = 20 * time.Second
+	defaultConnMgrLowWater  = 100
+	defaultConnMgrHighWater = 400
+)
+
+var infiniteResourceLimits = rcmgr.InfiniteLimits.ToPartialLimitConfig().System
+
+// connsFromMemory derives the maximum inbound connection count from a memory budget.
+// Uses 1 connection per MB, matching Kubo's derivation.
+func connsFromMemory(maxMem int64) int {
+	return int(maxMem / (1024 * 1024))
+}
+
+// buildResourceManager constructs a libp2p resource manager derived from the given limits.
+//
+// Derivation rules adapted from Kubo (https://github.com/ipfs/kubo),
+//   - System.Memory       = MaxMemory (or half of system RAM if zero)
+//   - System.ConnsInbound = 1 per MB of MaxMemory
+//   - Transient scope     = 25% of System scope
+//   - PeerDefault         = autoscaled by libp2p (DefaultLimit sentinel)
+//   - Service/Protocol    = unlimited
+func buildResourceManager(limits ResourceLimits) (network.ResourceManager, error) {
+	maxMem := limits.MaxMemory
+	if maxMem == 0 {
+		maxMem = int64(memory.TotalMemory()) / 2
+	}
+	fds := limits.MaxFileDescriptors
+	conns := connsFromMemory(maxMem)
+
+	partialLimits := rcmgr.PartialLimitConfig{
+		System: rcmgr.ResourceLimits{
+			Memory:       rcmgr.LimitVal64(maxMem),
+			Conns:        rcmgr.Unlimited,
+			ConnsInbound: rcmgr.LimitVal(conns),
+		},
+		// Transient connections are limited to 25% of system resources.
+		Transient: rcmgr.ResourceLimits{
+			Memory:       rcmgr.LimitVal64(maxMem / 4),
+			Conns:        rcmgr.Unlimited,
+			ConnsInbound: rcmgr.LimitVal(conns / 4),
+		},
+		// Constrain inbound only — guards against unintentional overuse by a single peer.
+		// Not a DoS defense: an attacker can spin up multiple peer IDs.
+		PeerDefault: rcmgr.ResourceLimits{
+			ConnsInbound:   rcmgr.DefaultLimit,
+			StreamsInbound: rcmgr.DefaultLimit,
+		},
+		// Keep service and protocol scopes unlimited for simplicity.
+		ServiceDefault:      infiniteResourceLimits,
+		ServicePeerDefault:  infiniteResourceLimits,
+		ProtocolDefault:     infiniteResourceLimits,
+		ProtocolPeerDefault: infiniteResourceLimits,
+		Conn:                infiniteResourceLimits,
+		Stream:              infiniteResourceLimits,
+	}
+
+	// Only apply FD limits if it's set, zero value will cause a block all limit
+	if fds > 0 {
+		partialLimits.System.FD = rcmgr.LimitVal(fds)
+		partialLimits.Transient.FD = rcmgr.LimitVal(fds / 4)
+	}
+
+	scalingLimitConfig := rcmgr.DefaultLimits
+	libp2p.SetDefaultServiceLimits(&scalingLimitConfig)
+	limitConfig := partialLimits.Build(scalingLimitConfig.Scale(maxMem, fds))
+
+	return rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(limitConfig))
+}
+
+func defaultConnManager() (iconnmgr.ConnManager, error) {
+	return connmgr.NewConnManager(defaultConnMgrLowWater, defaultConnMgrHighWater, connmgr.WithGracePeriod(connMgrGracePeriod))
+}
+
+func buildConnManager(limits ResourceLimits) (iconnmgr.ConnManager, error) {
+	maxMem := limits.MaxMemory
+	if maxMem == 0 {
+		maxMem = int64(memory.TotalMemory()) / 2
+	}
+	// setting high watermark to half of the max connections
+	highWater := connsFromMemory(maxMem) / 2
+	// setting low watermark at 25% of high watermark
+	lowWater := highWater / 4
+	return connmgr.NewConnManager(lowWater, highWater, connmgr.WithGracePeriod(connMgrGracePeriod))
+}
+
+// buildResourceControls returns the connmgr and optional resource manager for the given options.
+// The two are built together to ensure their limits are consistent with each other.
+func buildResourceControls(options *Options) (iconnmgr.ConnManager, network.ResourceManager, error) {
+	if options.ResourceManager != nil {
+		cm, err := defaultConnManager()
+		return cm, options.ResourceManager, err
+	}
+
+	if options.ResourceLimits.HasValue() {
+		limits := options.ResourceLimits.Value()
+		cm, err := buildConnManager(limits)
+		if err != nil {
+			return nil, nil, err
+		}
+		rm, err := buildResourceManager(limits)
+		if err != nil {
+			return nil, nil, err
+		}
+		return cm, rm, nil
+	}
+
+	// Neither set — preserve original defaults, no resource manager.
+	cm, err := defaultConnManager()
+	return cm, nil, err
+}

--- a/resource_manager.go
+++ b/resource_manager.go
@@ -27,9 +27,32 @@ const (
 	connMgrGracePeriod      = 20 * time.Second
 	defaultConnMgrLowWater  = 100
 	defaultConnMgrHighWater = 400
+
+	minMaxMemory          = 128 << 20 // 128 MiB
+	minMaxFileDescriptors = 256
 )
 
 var infiniteResourceLimits = rcmgr.InfiniteLimits.ToPartialLimitConfig().System
+
+// validate returns an error if any field of ResourceLimits is invalid.
+// Negative values are rejected because libp2p interprets -1 as Unlimited
+// and -2 as BlockAll, silently producing unintended behavior.
+// Values below the minimum thresholds are rejected to prevent misconfiguration.
+func (rl ResourceLimits) validate() error {
+	if rl.MaxMemory < 0 {
+		return ErrNegativeMaxMemory
+	}
+	if rl.MaxMemory > 0 && rl.MaxMemory < minMaxMemory {
+		return ErrMaxMemoryTooLow
+	}
+	if rl.MaxFileDescriptors < 0 {
+		return ErrNegativeMaxFileDescriptors
+	}
+	if rl.MaxFileDescriptors > 0 && rl.MaxFileDescriptors < minMaxFileDescriptors {
+		return ErrMaxFileDescriptorsTooLow
+	}
+	return nil
+}
 
 // connsFromMemory derives the maximum inbound connection count from a memory budget.
 // Uses 1 connection per MB, matching Kubo's derivation.
@@ -55,21 +78,39 @@ func buildResourceManager(limits ResourceLimits) (network.ResourceManager, error
 
 	partialLimits := rcmgr.PartialLimitConfig{
 		System: rcmgr.ResourceLimits{
-			Memory:       rcmgr.LimitVal64(maxMem),
-			Conns:        rcmgr.Unlimited,
-			ConnsInbound: rcmgr.LimitVal(conns),
+			Memory: rcmgr.LimitVal64(maxMem),
+
+			Conns:         rcmgr.Unlimited,
+			ConnsInbound:  rcmgr.LimitVal(conns),
+			ConnsOutbound: rcmgr.Unlimited,
+
+			Streams:         rcmgr.Unlimited,
+			StreamsOutbound: rcmgr.Unlimited,
+			StreamsInbound:  rcmgr.Unlimited,
 		},
 		// Transient connections are limited to 25% of system resources.
 		Transient: rcmgr.ResourceLimits{
-			Memory:       rcmgr.LimitVal64(maxMem / 4),
-			Conns:        rcmgr.Unlimited,
-			ConnsInbound: rcmgr.LimitVal(conns / 4),
+			Memory: rcmgr.LimitVal64(maxMem / 4),
+
+			Conns:         rcmgr.Unlimited,
+			ConnsInbound:  rcmgr.LimitVal(conns / 4),
+			ConnsOutbound: rcmgr.Unlimited,
+
+			Streams:         rcmgr.Unlimited,
+			StreamsInbound:  rcmgr.Unlimited,
+			StreamsOutbound: rcmgr.Unlimited,
 		},
 		// Constrain inbound only — guards against unintentional overuse by a single peer.
 		// Not a DoS defense: an attacker can spin up multiple peer IDs.
 		PeerDefault: rcmgr.ResourceLimits{
-			ConnsInbound:   rcmgr.DefaultLimit,
-			StreamsInbound: rcmgr.DefaultLimit,
+			Memory:          rcmgr.Unlimited64,
+			FD:              rcmgr.Unlimited,
+			Conns:           rcmgr.Unlimited,
+			ConnsInbound:    rcmgr.DefaultLimit,
+			ConnsOutbound:   rcmgr.Unlimited,
+			Streams:         rcmgr.Unlimited,
+			StreamsInbound:  rcmgr.DefaultLimit,
+			StreamsOutbound: rcmgr.Unlimited,
 		},
 		// Keep service and protocol scopes unlimited for simplicity.
 		ServiceDefault:      infiniteResourceLimits,
@@ -80,7 +121,7 @@ func buildResourceManager(limits ResourceLimits) (network.ResourceManager, error
 		Stream:              infiniteResourceLimits,
 	}
 
-	// Only apply FD limits if it's set, zero value will cause a block all limit
+	// Only apply FD limits when explicitly set
 	if fds > 0 {
 		partialLimits.System.FD = rcmgr.LimitVal(fds)
 		partialLimits.Transient.FD = rcmgr.LimitVal(fds / 4)
@@ -88,7 +129,14 @@ func buildResourceManager(limits ResourceLimits) (network.ResourceManager, error
 
 	scalingLimitConfig := rcmgr.DefaultLimits
 	libp2p.SetDefaultServiceLimits(&scalingLimitConfig)
-	limitConfig := partialLimits.Build(scalingLimitConfig.Scale(maxMem, fds))
+	var base rcmgr.ConcreteLimitConfig
+	if fds > 0 {
+		base = scalingLimitConfig.Scale(maxMem, fds)
+	} else {
+		// fds == 0: let libp2p detect system FDs via AutoScale.
+		base = scalingLimitConfig.AutoScale()
+	}
+	limitConfig := partialLimits.Build(base)
 
 	return rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(limitConfig))
 }
@@ -119,6 +167,9 @@ func buildResourceControls(options *Options) (iconnmgr.ConnManager, network.Reso
 
 	if options.ResourceLimits.HasValue() {
 		limits := options.ResourceLimits.Value()
+		if err := limits.validate(); err != nil {
+			return nil, nil, err
+		}
 		cm, err := buildConnManager(limits)
 		if err != nil {
 			return nil, nil, err

--- a/resource_manager_test.go
+++ b/resource_manager_test.go
@@ -98,6 +98,42 @@ func TestBuildResourceManager_ZeroMemory(t *testing.T) {
 	rm.Close()
 }
 
+// TestBuildResourceControls_NegativeMemory verifies that negative MaxMemory is rejected.
+func TestBuildResourceControls_NegativeMemory(t *testing.T) {
+	opts := &Options{
+		ResourceLimits: immutable.Some(ResourceLimits{MaxMemory: -1}),
+	}
+	_, _, err := buildResourceControls(opts)
+	assert.ErrorIs(t, err, ErrNegativeMaxMemory)
+}
+
+// TestBuildResourceControls_NegativeFDs verifies that negative MaxFileDescriptors is rejected.
+func TestBuildResourceControls_NegativeFDs(t *testing.T) {
+	opts := &Options{
+		ResourceLimits: immutable.Some(ResourceLimits{MaxFileDescriptors: -1}),
+	}
+	_, _, err := buildResourceControls(opts)
+	assert.ErrorIs(t, err, ErrNegativeMaxFileDescriptors)
+}
+
+// TestBuildResourceControls_MemoryTooLow verifies that a non-zero MaxMemory below 128 MiB is rejected.
+func TestBuildResourceControls_MemoryTooLow(t *testing.T) {
+	opts := &Options{
+		ResourceLimits: immutable.Some(ResourceLimits{MaxMemory: 64 << 20}),
+	}
+	_, _, err := buildResourceControls(opts)
+	assert.ErrorIs(t, err, ErrMaxMemoryTooLow)
+}
+
+// TestBuildResourceControls_FDsTooLow verifies that a non-zero MaxFileDescriptors below 128 is rejected.
+func TestBuildResourceControls_FDsTooLow(t *testing.T) {
+	opts := &Options{
+		ResourceLimits: immutable.Some(ResourceLimits{MaxMemory: testMemory128MB, MaxFileDescriptors: 128}),
+	}
+	_, _, err := buildResourceControls(opts)
+	assert.ErrorIs(t, err, ErrMaxFileDescriptorsTooLow)
+}
+
 // TestBuildResourceControls_NeitherSet verifies default connmgr is returned
 // with no resource manager when neither option is set.
 func TestBuildResourceControls_NeitherSet(t *testing.T) {

--- a/resource_manager_test.go
+++ b/resource_manager_test.go
@@ -1,0 +1,136 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p2p
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/sourcenetwork/immutable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testMemory128MB = 128 * 1024 * 1024
+
+// TestConnsFromMemory verifies the 1-conn-per-MB derivation rule.
+func TestConnsFromMemory(t *testing.T) {
+	assert.Equal(t, 128, connsFromMemory(128*1024*1024))
+	assert.Equal(t, 1024, connsFromMemory(1024*1024*1024))
+}
+
+// TestBuildResourceManager_SystemConnsInbound verifies that system-scope inbound
+// connections are capped at 1 per MB of MaxMemory.
+func TestBuildResourceManager_SystemConnsInbound(t *testing.T) {
+	rm, err := buildResourceManager(ResourceLimits{MaxMemory: testMemory128MB})
+	require.NoError(t, err)
+	defer rm.Close()
+
+	conns := make([]network.ConnManagementScope, 128)
+	defer func() {
+		for _, c := range conns {
+			if c != nil {
+				c.Done()
+			}
+		}
+	}()
+
+	for i := range conns {
+		addr := multiaddr.StringCast(fmt.Sprintf("/ip4/1.2.3.%d/tcp/1234", i%255+1))
+		conns[i], err = rm.OpenConnection(network.DirInbound, false, addr)
+		require.NoError(t, err)
+		// Move out of transient scope so the system limit is exercised.
+		err = conns[i].SetPeer(peer.ID(fmt.Sprintf("peer%d", i)))
+		require.NoError(t, err)
+	}
+
+	addr := multiaddr.StringCast("/ip4/1.3.4.1/tcp/1234")
+	_, err = rm.OpenConnection(network.DirInbound, false, addr)
+	assert.Error(t, err, "should reject 129th system inbound connection")
+}
+
+// TestBuildResourceManager_TransientConnsInbound verifies that transient inbound
+// connections are capped at 25% of the system inbound limit.
+func TestBuildResourceManager_TransientConnsInbound(t *testing.T) {
+	rm, err := buildResourceManager(ResourceLimits{MaxMemory: testMemory128MB})
+	require.NoError(t, err)
+	defer rm.Close()
+
+	conns := make([]network.ConnManagementScope, 32)
+	defer func() {
+		for _, c := range conns {
+			if c != nil {
+				c.Done()
+			}
+		}
+	}()
+
+	for i := range conns {
+		addr := multiaddr.StringCast(fmt.Sprintf("/ip4/1.2.3.%d/tcp/1234", i%255+1))
+		conns[i], err = rm.OpenConnection(network.DirInbound, false, addr)
+		require.NoError(t, err)
+	}
+
+	addr := multiaddr.StringCast("/ip4/1.3.4.1/tcp/1234")
+	_, err = rm.OpenConnection(network.DirInbound, false, addr)
+	assert.Error(t, err, "should reject 33rd transient inbound connection")
+}
+
+// TestBuildResourceManager_ZeroMemory verifies that a zero MaxMemory falls back
+// to half of system RAM without error.
+func TestBuildResourceManager_ZeroMemory(t *testing.T) {
+	rm, err := buildResourceManager(ResourceLimits{})
+	require.NoError(t, err)
+	assert.NotNil(t, rm)
+	rm.Close()
+}
+
+// TestBuildResourceControls_NeitherSet verifies default connmgr is returned
+// with no resource manager when neither option is set.
+func TestBuildResourceControls_NeitherSet(t *testing.T) {
+	cm, rm, err := buildResourceControls(&Options{})
+	require.NoError(t, err)
+	assert.NotNil(t, cm)
+	assert.Nil(t, rm)
+}
+
+// TestBuildResourceControls_LimitsOnly verifies that both connmgr and resource
+// manager are returned when only ResourceLimits is set.
+func TestBuildResourceControls_LimitsOnly(t *testing.T) {
+	opts := &Options{
+		ResourceLimits: immutable.Some(ResourceLimits{MaxMemory: testMemory128MB}),
+	}
+	cm, rm, err := buildResourceControls(opts)
+	require.NoError(t, err)
+	assert.NotNil(t, cm)
+	assert.NotNil(t, rm)
+	rm.Close()
+}
+
+// TestBuildResourceControls_ResourceManagerOverrides verifies that when ResourceManager
+// is set it takes precedence over ResourceLimits.
+func TestBuildResourceControls_ResourceManagerOverrides(t *testing.T) {
+	customRM := &network.NullResourceManager{}
+	opts := &Options{
+		ResourceManager: customRM,
+		ResourceLimits:  immutable.Some(ResourceLimits{MaxMemory: testMemory128MB}),
+	}
+	cm, rm, err := buildResourceControls(opts)
+	require.NoError(t, err)
+	assert.NotNil(t, cm)
+	assert.Equal(t, customRM, rm)
+
+}


### PR DESCRIPTION
Related https://github.com/sourcenetwork/defradb/issues/421
Discussion https://github.com/sourcenetwork/defradb/pull/4629#discussion_r2955565445

## Current State
After PR https://github.com/sourcenetwork/go-p2p/pull/22 a caller of `go-p2p` could use `WithResourceManager` as to manage p2p resources but required callers to construct a full `network.ResourceManager` with all libp2p internals, leaking those details into defradb's node package.

Additionally, `connmgr` was hardcoded to 100/400 regardless of any resource configuration, meaning even if a resource manager was configured, `connmgr` would either silently cap connections well below intended limits or never kick in.

What changed

- Added `ResourceLimits` type to `Options` with `MaxMemory` and `MaxFileDescriptors` fields
- Added `WithResourceLimits` option for high-level resource configuration — connection limits are derived internally using a derivation (1 conn/MB, transient = 25% of system)
- Added `buildResourceControls` which constructs both `connmgr` and `ResourceManager` from the same `ResourceLimits`, ensuring they are consistent with each other when `ResourceLimits` are set.
- `WithResourceManager` is preserved as an escape hatch — when set it takes precedence over `ResourceLimits`