### PR TITLE
feat: Replace Bitswap with Blockfetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
 # p2p
-P2P package for SourceNetwork projects
+
+P2P package for SourceNetwork projects. Wraps a libp2p host with conveniences for
+pubsub, peer management, and content-addressed block exchange.
+
+## Block exchange (`/sourcenetwork/blockfetch/1.0.0`)
+
+Block exchange is served by a small libp2p stream protocol — not bitswap.
+
+### Why not bitswap
+
+Bitswap is built for the open IPFS network: it maintains per-peer want-lists, runs
+provider discovery through the DHT, scores peers, and broadcasts wants to every
+connected peer. That comes with a fleet of background goroutines (session
+manager, want-manager, peer manager, decision engine, response queue, …) and a
+lot of cross-peer chatter.
+
+Our usage pattern is much narrower:
+
+- A sync is almost always triggered by a pubsub announcement from a known
+  sender, so the peer that has the blocks is already in hand.
+- Blocks are content-addressed and self-verifying, so we don't need bitswap's
+  reputation / scoring machinery.
+- DAG walks are sequential — one block at a time.
+
+Bitswap's machinery is wasted under that pattern, and its scheduling patterns
+misbehave on the single-threaded `GOOS=js GOARCH=wasm` runtime, where tight
+coordination loops can starve cooperative goroutines.
+
+### How it works
+
+A directed request/response protocol over a libp2p stream:
+
+1. Client opens a stream to the target peer on `/sourcenetwork/blockfetch/1.0.0`.
+2. Client encodes one CBOR request: `{c: <CID bytes>}`.
+3. Server reads the request, runs the access check, looks up the block locally,
+   encodes one CBOR reply: `{s: status, d: <block bytes>}` where `status` is
+   `0=OK`, `1=NotFound`, `2=Denied`.
+4. Both sides close the stream.
+
+One CID per stream, full-duplex, no message-id correlation, no background
+workers. The stream handler goroutine is spawned by libp2p per inbound stream
+and exits when the stream closes.
+
+### Sessions and peer selection
+
+`(*Peer).ContextWithSession(ctx, peerIDs...)` attaches a list of candidate peers
+to the context. The IPLD store consults that list when serving a remote read:
+
+- With explicit peer IDs, candidates are tried in order with a per-peer timeout.
+  The first OK response wins; `NotFound` or `Denied` falls through to the next
+  candidate. This is the targeted path — the caller already knows who has the
+  data (typically the announcer of the pubsub message that triggered the sync).
+- With no peer IDs, the store falls back to every currently-connected peer.
+  This is the discovery path used by flows like collection-version sync where
+  no specific sender is known up front.
+
+### Access control
+
+`(*Peer).SetBlockAccessFunc(fn)` installs a `BlockAccessFunc` predicate that the
+server consults before serving each block. Returning `false` produces a `Denied`
+reply. A nil func (the default) means open access, matching bitswap's
+out-of-the-box behaviour.
+
+### IPLD store
+
+`(*Peer).IPLDStore()` returns a `storage.ReadableStorage` + `storage.WritableStorage`
+implementation that:
+
+- on read, checks the local blockstore first and falls back to remote peers via
+  the protocol above, writing successful fetches through to the local store so
+  subsequent reads stay local;
+- on write, stores to the local blockstore only.
+
+Plug this into a go-ipld-prime `LinkSystem` and DAG walks transparently fan out
+to remote peers as needed.

--- a/blockfetch.go
+++ b/blockfetch.go
@@ -1,0 +1,260 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p2p
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime/storage"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+)
+
+// blockFetchProtocol is the libp2p protocol ID under which a Peer answers
+// content-addressed block fetches.
+const blockFetchProtocol protocol.ID = "/sourcenetwork/blockfetch/1.0.0"
+
+// blockFetchPerPeerTimeout caps how long we wait for any single peer to answer a fetch.
+//
+// A short timeout keeps a slow or unresponsive peer from blocking the entire DAG walk.
+const blockFetchPerPeerTimeout = 5 * time.Second
+
+type blockFetchStatus uint8
+
+const (
+	blockFetchStatusOK       blockFetchStatus = 0
+	blockFetchStatusNotFound blockFetchStatus = 1
+	blockFetchStatusDenied   blockFetchStatus = 2
+)
+
+// blockFetchRequest asks a remote peer for a single block by CID.
+type blockFetchRequest struct {
+	CID []byte `cbor:"c"`
+}
+
+// blockFetchReply carries the response for a blockFetchRequest.
+type blockFetchReply struct {
+	Status blockFetchStatus `cbor:"s"`
+	Data   []byte           `cbor:"d,omitempty"`
+}
+
+// sessionKey is the context key under which a fetch session stores its candidate peer IDs.
+type sessionKey struct{}
+
+func sessionPeers(ctx context.Context) []string {
+	v, _ := ctx.Value(sessionKey{}).([]string)
+	return v
+}
+
+// handleBlockFetch is the libp2p stream handler for inbound block requests.
+//
+// One request, one reply, then close. Access decisions defer to the peer's
+// configured BlockAccessFunc (if any); a missing func means open access, which
+// matches the bitswap-era default.
+func (p *Peer) handleBlockFetch(s network.Stream) {
+	defer s.Close()
+
+	var req blockFetchRequest
+	if err := cbor.NewDecoder(s).Decode(&req); err != nil {
+		_ = s.Reset()
+		return
+	}
+
+	c, err := cid.Cast(req.CID)
+	if err != nil {
+		_ = cbor.NewEncoder(s).Encode(blockFetchReply{Status: blockFetchStatusNotFound})
+		return
+	}
+
+	if !p.hasAccess(s.Conn().RemotePeer(), c) {
+		_ = cbor.NewEncoder(s).Encode(blockFetchReply{Status: blockFetchStatusDenied})
+		return
+	}
+
+	block, err := p.blockstore.Get(p.ctx, c)
+	if err != nil {
+		_ = cbor.NewEncoder(s).Encode(blockFetchReply{Status: blockFetchStatusNotFound})
+		return
+	}
+
+	_ = cbor.NewEncoder(s).Encode(blockFetchReply{
+		Status: blockFetchStatusOK,
+		Data:   block.RawData(),
+	})
+}
+
+// fetchBlockFromPeer opens a stream, sends a single CID request, and reads the reply.
+func (p *Peer) fetchBlockFromPeer(ctx context.Context, pid peer.ID, c cid.Cid) (blockFetchReply, error) {
+	s, err := p.host.NewStream(ctx, pid, blockFetchProtocol)
+	if err != nil {
+		return blockFetchReply{}, err
+	}
+
+	if err := cbor.NewEncoder(s).Encode(blockFetchRequest{CID: c.Bytes()}); err != nil {
+		_ = s.Reset()
+		return blockFetchReply{}, err
+	}
+
+	var reply blockFetchReply
+	if err := cbor.NewDecoder(s).Decode(&reply); err != nil {
+		_ = s.Reset()
+		return blockFetchReply{}, err
+	}
+
+	_ = s.Close()
+	return reply, nil
+}
+
+// remoteIPLDStore implements ipld-prime's storage.ReadableStorage and storage.WritableStorage.
+//
+// Reads check the local blockstore first. On a miss, it asks the peers in the
+// fetch session (or, if none were supplied, every currently-connected peer)
+// over the blockfetch protocol. The first peer that returns OK wins; the block
+// is written through to the local blockstore so subsequent reads stay local.
+//
+// Writes go to the local blockstore only.
+type remoteIPLDStore struct {
+	peer *Peer
+}
+
+var (
+	_ storage.ReadableStorage = (*remoteIPLDStore)(nil)
+	_ storage.WritableStorage = (*remoteIPLDStore)(nil)
+)
+
+func (s *remoteIPLDStore) Has(ctx context.Context, key string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	c, err := cidFromKey(key)
+	if err != nil {
+		return false, err
+	}
+	return s.peer.blockstore.Has(ctx, c)
+}
+
+func (s *remoteIPLDStore) Get(ctx context.Context, key string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	c, err := cidFromKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if has, herr := s.peer.blockstore.Has(ctx, c); herr == nil && has {
+		block, gerr := s.peer.blockstore.Get(ctx, c)
+		if gerr == nil {
+			return block.RawData(), nil
+		}
+	}
+
+	data, ok, err := s.peer.fetchRemote(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrBlockNotFound
+	}
+
+	block, err := blocks.NewBlockWithCid(data, c)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.peer.blockstore.Put(ctx, block); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (s *remoteIPLDStore) Put(ctx context.Context, key string, content []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	c, err := cidFromKey(key)
+	if err != nil {
+		return err
+	}
+	block, err := blocks.NewBlockWithCid(content, c)
+	if err != nil {
+		return err
+	}
+	return s.peer.blockstore.Put(ctx, block)
+}
+
+// fetchRemote tries each candidate peer in turn and returns the first OK block.
+//
+// NotFound and Denied responses fall through to the next peer; transport
+// errors do too. Returns (nil, false, nil) if no peer had the block.
+func (p *Peer) fetchRemote(ctx context.Context, c cid.Cid) ([]byte, bool, error) {
+	pids := p.candidatePeers(ctx)
+	self := p.host.ID()
+
+	for _, pid := range pids {
+		if pid == self {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+
+		peerCtx, cancel := context.WithTimeout(ctx, blockFetchPerPeerTimeout)
+		reply, err := p.fetchBlockFromPeer(peerCtx, pid, c)
+		cancel()
+		if err != nil {
+			continue
+		}
+		if reply.Status == blockFetchStatusOK {
+			return reply.Data, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+// candidatePeers returns the peer IDs that this fetch should try, in order.
+//
+// If the context carries an explicit session, those peers are used. Otherwise
+// it falls back to every currently-connected peer (matching the broadcast-style
+// behaviour of bitswap discovery flows).
+func (p *Peer) candidatePeers(ctx context.Context) []peer.ID {
+	sessIDs := sessionPeers(ctx)
+	if len(sessIDs) > 0 {
+		out := make([]peer.ID, 0, len(sessIDs))
+		for _, s := range sessIDs {
+			pid, err := peer.Decode(s)
+			if err != nil {
+				continue
+			}
+			out = append(out, pid)
+		}
+		return out
+	}
+	return p.host.Network().Peers()
+}
+
+func cidFromKey(key string) (cid.Cid, error) {
+	n, c, err := cid.CidFromBytes([]byte(key))
+	if err != nil {
+		return cid.Undef, fmt.Errorf("blockfetch: key was not a cid: %w", err)
+	}
+	if n != len(key) {
+		return cid.Undef, fmt.Errorf("blockfetch: key had %d trailing bytes", len(key)-n)
+	}
+	return c, nil
+}

--- a/errors.go
+++ b/errors.go
@@ -28,6 +28,8 @@ var (
 	// ErrHashMismatch is an error returned when the hash of a block is different than expected.
 	ErrHashMismatch             = errors.New("block in storage has different hash than requested")
 	ErrBlockstoreOrRootRequired = errors.New("either blockstore or rootstore must be provided")
+	// ErrBlockNotFound is returned when no peer in the active session could supply the requested block.
+	ErrBlockNotFound = errors.New("block not found")
 )
 
 func NewErrPushLog(inner error, topic string) error {

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/sourcenetwork/go-p2p
 go 1.25.7
 
 require (
+	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/ipfs/boxo v0.37.0
+	github.com/ipfs/go-block-format v0.2.3
 	github.com/ipfs/go-cid v0.6.0
-	github.com/ipld/go-ipld-prime/storage/bsrvadapter v0.0.0-20250821084354-a425e60cd714
+	github.com/ipld/go-ipld-prime v0.22.0
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/libp2p/go-libp2p-kad-dht v0.38.0
 	github.com/libp2p/go-libp2p-pubsub v0.15.0
@@ -29,7 +31,6 @@ require (
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cskr/pubsub v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
@@ -48,17 +49,13 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
-	github.com/ipfs/go-block-format v0.2.3 // indirect
 	github.com/ipfs/go-cidutil v0.1.1 // indirect
 	github.com/ipfs/go-datastore v0.9.1 // indirect
 	github.com/ipfs/go-dsqueue v0.2.0 // indirect
-	github.com/ipfs/go-ipfs-pq v0.0.4 // indirect
 	github.com/ipfs/go-ipld-format v0.6.3 // indirect
 	github.com/ipfs/go-log/v2 v2.9.1 // indirect
 	github.com/ipfs/go-metrics-interface v0.3.0 // indirect
-	github.com/ipfs/go-peertaskqueue v0.8.3 // indirect
 	github.com/ipfs/kubo v0.25.0 // indirect
-	github.com/ipld/go-ipld-prime v0.22.0 // indirect
 	github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
@@ -124,6 +121,7 @@ require (
 	github.com/tidwall/btree v1.7.0 // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=
+github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gammazero/chanqueue v1.1.2 h1:dZEsxlyANZMyeTRemABqZF8QM9BnE4NBI43Oh3y5fIU=
 github.com/gammazero/chanqueue v1.1.2/go.mod h1:XDN1X/jjAbmSceNFOQbtKToeSkxtdVdpKu90LiEdBEE=
 github.com/gammazero/deque v1.2.1 h1:9fnQVFCCZ9/NOc7ccTNqzoKd1tCWOqeI05/lPqFPMGQ=
@@ -299,8 +301,6 @@ github.com/ipld/go-ipld-prime v0.22.0 h1:YJhDhjEOvOYaqshd3b4atIWUoRg/rKrgmwCyUHw
 github.com/ipld/go-ipld-prime v0.22.0/go.mod h1:ol7vKxOOVgEh0iAPuiDalM+0gScXVMA5ZZa4DVrTnEA=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714 h1:cqNk8PEwHnK0vqWln+U/YZhQc9h2NB3KjUjDPZo5Q2s=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714/go.mod h1:ZEUdra3CoqRVRYgAX/jAJO9aZGz6SKtKEG628fHHktY=
-github.com/ipld/go-ipld-prime/storage/bsrvadapter v0.0.0-20250821084354-a425e60cd714 h1:i0Wz7cBRMieyYxf8o15yxhbb8dYcOkbf9UDc1MxdjrI=
-github.com/ipld/go-ipld-prime/storage/bsrvadapter v0.0.0-20250821084354-a425e60cd714/go.mod h1:fGZj8O/l/fZw9vyZfrkWJ4Ahp4JOEtkfbYd3ApymT2k=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABoLk/+KKHggpk=
@@ -568,6 +568,8 @@ github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdz
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
 github.com/wlynxg/anet v0.0.5 h1:J3VJGi1gvo0JwZ/P1/Yc/8p63SoW98B5dHkYDmpgvvU=
 github.com/wlynxg/anet v0.0.5/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/host.go
+++ b/host.go
@@ -17,8 +17,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/ipfs/boxo/blockservice"
-	"github.com/ipld/go-ipld-prime/storage/bsrvadapter"
 	libp2p "github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	dualdht "github.com/libp2p/go-libp2p-kad-dht/dual"
@@ -327,12 +325,17 @@ func (p *Peer) publishToTopic(
 
 // IPLDStore returns the a wrapped blockservice.BlockService that implements the blockstore.IPLDStore interface.
 func (p *Peer) IPLDStore() blockstore.IPLDStore {
-	return &bsrvadapter.Adapter{Wrapped: p.blockService}
+	return &remoteIPLDStore{peer: p}
 }
 
 // ContextWithSession returns a context with a session for the blockservice.
-func (p *Peer) ContextWithSession(ctx context.Context) context.Context {
-	return blockservice.ContextWithSession(ctx, p.blockService)
+//
+// Pass the IDs of peers known to hold the blocks you are about to fetch (e.g.
+// the sender of the pubsub announcement that triggered the sync). With no IDs,
+// the resulting context falls back to all currently-connected peers, matching
+// bitswap's broadcast-style discovery.
+func (p *Peer) ContextWithSession(ctx context.Context, peerIDs ...string) context.Context {
+	return context.WithValue(ctx, sessionKey{}, peerIDs)
 }
 
 func (p *Peer) SetBlockAccessFunc(accessFunc BlockAccessFunc) {

--- a/peer.go
+++ b/peer.go
@@ -18,9 +18,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ipfs/boxo/bitswap"
-	"github.com/ipfs/boxo/bitswap/network/bsnet"
-	"github.com/ipfs/boxo/blockservice"
 	"github.com/ipfs/boxo/blockstore"
 	"github.com/ipfs/boxo/bootstrap"
 	"github.com/ipfs/go-cid"
@@ -51,8 +48,8 @@ type Peer struct {
 	topics  map[string]pubsubTopic
 	topicMu sync.Mutex
 
-	// peer DAG service
-	blockService blockservice.BlockService
+	// blockstore is the local store used to serve and persist blocks.
+	blockstore blockstore.Blockstore
 
 	bootCloser io.Closer
 
@@ -127,6 +124,7 @@ func NewPeer(
 		ctx:                 ctx,
 		cancel:              cancel,
 		topics:              make(map[string]pubsubTopic),
+		blockstore:          options.Blockstore.Value(),
 		clearBackoffOnRetry: options.ClearBackoffOnRetry,
 	}
 
@@ -142,9 +140,7 @@ func NewPeer(
 		}
 	}
 
-	bswapnet := bsnet.NewFromIpfsHost(h)
-	bswap := bitswap.New(ctx, bswapnet, ddht, options.Blockstore.Value(), bitswap.WithPeerBlockRequestFilter(p.hasAccess))
-	p.blockService = blockservice.New(options.Blockstore.Value(), bswap)
+	h.SetStreamHandler(blockFetchProtocol, p.handleBlockFetch)
 
 	p.bootCloser, err = bootstrap.Bootstrap(h.ID(), h, ddht, bootstrap.BootstrapConfigWithPeers(peers))
 	if err != nil {
@@ -186,10 +182,6 @@ func (p *Peer) Close() {
 
 	if err := p.removeAllPubsubTopics(); err != nil {
 		log.ErrorE("Error closing pubsub topics", err)
-	}
-
-	if err := p.blockService.Close(); err != nil {
-		log.ErrorE("Error closing block service", err)
 	}
 
 	if err := p.host.Close(); err != nil {


### PR DESCRIPTION
This PR replaces Bitswap with a new Blockfetch protocol.

## Block exchange (`/sourcenetwork/blockfetch/1.0.0`)

Block exchange is served by a small libp2p stream protocol — not bitswap.

### Why not bitswap

Bitswap is built for the open IPFS network: it maintains per-peer want-lists, runs
provider discovery through the DHT, scores peers, and broadcasts wants to every
connected peer. That comes with a fleet of background goroutines (session
manager, want-manager, peer manager, decision engine, response queue, …) and a
lot of cross-peer chatter.

Our usage pattern is much narrower:

- A sync is almost always triggered by a pubsub announcement from a known
  sender, so the peer that has the blocks is already in hand.
- Blocks are content-addressed and self-verifying, so we don't need bitswap's
  reputation / scoring machinery.
- DAG walks are sequential — one block at a time.

Bitswap's machinery is wasted under that pattern, and its scheduling patterns
misbehave on the single-threaded `GOOS=js GOARCH=wasm` runtime, where tight
coordination loops can starve cooperative goroutines.

### How it works

A directed request/response protocol over a libp2p stream:

1. Client opens a stream to the target peer on `/sourcenetwork/blockfetch/1.0.0`.
2. Client encodes one CBOR request: `{c: <CID bytes>}`.
3. Server reads the request, runs the access check, looks up the block locally,
   encodes one CBOR reply: `{s: status, d: <block bytes>}` where `status` is
   `0=OK`, `1=NotFound`, `2=Denied`.
4. Both sides close the stream.

One CID per stream, full-duplex, no message-id correlation, no background
workers. The stream handler goroutine is spawned by libp2p per inbound stream
and exits when the stream closes.

### Sessions and peer selection

`(*Peer).ContextWithSession(ctx, peerIDs...)` attaches a list of candidate peers
to the context. The IPLD store consults that list when serving a remote read:

- With explicit peer IDs, candidates are tried in order with a per-peer timeout.
  The first OK response wins; `NotFound` or `Denied` falls through to the next
  candidate. This is the targeted path — the caller already knows who has the
  data (typically the announcer of the pubsub message that triggered the sync).
- With no peer IDs, the store falls back to every currently-connected peer.
  This is the discovery path used by flows like collection-version sync where
  no specific sender is known up front.

### Access control

`(*Peer).SetBlockAccessFunc(fn)` installs a `BlockAccessFunc` predicate that the
server consults before serving each block. Returning `false` produces a `Denied`
reply. A nil func (the default) means open access, matching bitswap's
out-of-the-box behaviour.

### IPLD store

`(*Peer).IPLDStore()` returns a `storage.ReadableStorage` + `storage.WritableStorage`
implementation that:

- on read, checks the local blockstore first and falls back to remote peers via
  the protocol above, writing successful fetches through to the local store so
  subsequent reads stay local;
- on write, stores to the local blockstore only.

Plug this into a go-ipld-prime `LinkSystem` and DAG walks transparently fan out
to remote peers as needed.
