### PR TITLE
fix: close TCP connection on Disconnect

### DIFF
--- a/host.go
+++ b/host.go
@@ -188,7 +188,7 @@ func (p *Peer) Disconnect(ctx context.Context, peerID string) error {
 		return err
 	}
 	p.host.Peerstore().ClearAddrs(pid)
-	return nil
+	return p.host.Network().ClosePeer(pid)
 }
 
 func (p *Peer) Send(ctx context.Context, data []byte, peerID string, protocolID string) error {


### PR DESCRIPTION
 This fixes a limitation exposed by sourcenetwork/defradb#4879, where post-disconnect `ActivePeers` assertions could not be made because `Disconnect` only cleared the peerstore without closing the TCP connection.